### PR TITLE
Alpha beta pruning

### DIFF
--- a/src/bench.cpp
+++ b/src/bench.cpp
@@ -34,7 +34,7 @@ const char* benchFens[] = {
 
 void runBench()
 {
-    constexpr int BENCH_DEPTH = 7;
+    constexpr int BENCH_DEPTH = 10;
 
     SearchLimits limits = {};
     limits.maxDepth = BENCH_DEPTH;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -29,7 +29,7 @@ SearchResult Search::runSearch(const SearchLimits& limits, bool report)
     Move bestMove = Move{};
     for (int depth = 1; depth <= limits.maxDepth; depth++)
     {
-        int iterScore = search(depth, 0);
+        int iterScore = search(-SCORE_WIN, SCORE_WIN, depth, 0);
         if (m_ShouldStop)
             break;
         score = iterScore;
@@ -50,7 +50,7 @@ SearchResult Search::runSearch(const SearchLimits& limits, bool report)
     return SearchResult{score, bestMove};
 }
 
-int Search::search(int depth, int ply)
+int Search::search(int alpha, int beta, int depth, int ply)
 {
     // TODO: add better evaluation function
     // TODO: move evaluation into it's own file
@@ -78,7 +78,7 @@ int Search::search(int depth, int ply)
     {
         m_Nodes++;
         m_Board.makeMove(move);
-        int score = -search(depth - 1, ply + 1);
+        int score = -search(-beta, -alpha, depth - 1, ply + 1);
         m_Board.unmakeMove(move);
 
         if (m_ShouldStop)
@@ -87,8 +87,15 @@ int Search::search(int depth, int ply)
         if (score > bestScore)
         {
             bestScore = score;
-            if (root)
-                m_RootBestMove = move;
+            if (score > alpha)
+            {
+                alpha = score;
+                if (root)
+                    m_RootBestMove = move;
+            }
+
+            if (score >= beta)
+                break;
         }
     }
 

--- a/src/search.h
+++ b/src/search.h
@@ -18,7 +18,7 @@ public:
     SearchResult runSearch(const SearchLimits& limits, bool report = true);
     uint64_t runBenchSearch(const SearchLimits& limits);
 private:
-    int search(int depth, int ply);
+    int search(int alpha, int beta, int depth, int ply);
 
     Board m_Board;
     TimeMan m_TimeMan;


### PR DESCRIPTION
```
Score of uttt-alpha-beta vs uttt-negamax: 80 - 5 - 17 [0.868] 102
326.64 +/- 83.29
SPRT: llr 2.97, lbound -2.94, ubound 2.94
```

tc: 8+0.08
book: openings_5ply.txt
sprt bounds: [0, 10]

Bench: 83730290