### PR TITLE
TT move ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,9 @@ set(SRCS
     "src/time_man.cpp"
     "src/time_man.h"
     "src/types.h"
+    "src/zobrist.h"
 
+    "src/util/prng.h"
     "src/util/static_vector.h"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ set(SRCS
     "src/search.h"
     "src/time_man.cpp"
     "src/time_man.h"
+    "src/tt.cpp"
+    "src/tt.h"
     "src/types.h"
     "src/zobrist.h"
 

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -8,6 +8,7 @@ Board::Board()
     m_BoardStates.reserve(128);
     BoardState rootState = {};
     rootState.subBoardIdx = -1;
+    rootState.key.updateCurrSubBoard(rootState.subBoardIdx);
     m_BoardStates.push_back(rootState);
 }
 
@@ -81,6 +82,8 @@ void Board::setToFen(std::string_view fen)
         if ((subBoard(Color::X, i) | subBoard(Color::O, i)) == IN_BOARD)
             state().drawn |= Bitboard::fromSquare(i);
     }
+
+    state().key.updateCurrSubBoard(state().subBoardIdx);
 }
 
 std::string Board::fenStr() const
@@ -128,6 +131,7 @@ void Board::makeMove(Move move)
     m_BoardStates.push_back(state());
     auto& newState = state();
     newState.addPiece(m_SideToMove, move.to);
+    newState.key.updateCurrSubBoard(newState.subBoardIdx);
 
     if (attacks::boardIsWon(subBoard(m_SideToMove, move.to.subBoard())))
         newState.won[static_cast<int>(m_SideToMove)] |= Bitboard::fromSquare(move.to.subBoard());
@@ -136,6 +140,7 @@ void Board::makeMove(Move move)
 
     newState.subBoardIdx = move.to.subSquare();
     newState.prevSquare = move.to;
+    newState.key.updateCurrSubBoard(newState.subBoardIdx);
 
     newState.key.flipSideToMove();
 

--- a/src/board.h
+++ b/src/board.h
@@ -42,6 +42,7 @@ public:
     Bitboard drawnBoards() const;
     Bitboard completedBoards() const;
     Piece pieceAt(Square sq) const;
+    ZKey key() const;
 
     int subBoardIdx() const;
     Color sideToMove() const;
@@ -87,6 +88,11 @@ inline Piece Board::pieceAt(Square sq) const
     if ((subBoardO & Bitboard::fromSquare(sq.subSquare())).any())
         return Piece::O;
     return Piece::NONE;
+}
+
+inline ZKey Board::key() const
+{
+    return state().key;
 }
 
 inline int Board::subBoardIdx() const

--- a/src/board.h
+++ b/src/board.h
@@ -3,17 +3,25 @@
 #include "types.h"
 #include "bitboard.h"
 #include "attacks.h"
+#include "zobrist.h"
 #include <vector>
 
 struct BoardState
 {
-    Bitboard subBoards[9][2];
+    Bitboard subBoards[2][9];
     Bitboard won[2];
     Bitboard drawn;
 
     int subBoardIdx;
+    ZKey key;
 
     Square prevSquare;
+
+    void addPiece(Color color, Square square)
+    {
+        subBoards[static_cast<int>(color)][square.subBoard()] |= Bitboard::fromSquare(square.subSquare());
+        key.addPiece(color, square);
+    }
 };
 
 class Board
@@ -24,7 +32,7 @@ public:
     void setToFen(std::string_view fen);
 
     void makeMove(Move move);
-    void unmakeMove(Move move);
+    void unmakeMove();
 
     std::string stringRep() const;
     std::string fenStr() const;
@@ -51,7 +59,7 @@ private:
 
 inline Bitboard Board::subBoard(Color color, int subBoardIdx) const
 {
-    return state().subBoards[subBoardIdx][static_cast<int>(color)];
+    return state().subBoards[static_cast<int>(color)][subBoardIdx];
 }
 
 inline Bitboard Board::wonBoards(Color color) const

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -372,7 +372,9 @@ int main()
         }
         else if (tok == "d")
         {
-            std::cout << currBoard.stringRep() << std::endl;
+            std::cout << currBoard.stringRep();
+            std::cout << "Side to move: " << (currBoard.sideToMove() == Color::X ? 'X' : 'O') << std::endl;
+            std::cout << "Zobrist hash: " << std::hex << (currBoard.key().value) << std::endl;
         }
         else if (tok == "genopenings")
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,6 +208,7 @@ int main()
         {
             currBoard.setToFen("9/9/9/9/9/9/9/9/9 X 0 0000");
             player1 = currBoard.sideToMove();
+            search.newGame();
         }
         else if (tok == "position")
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@ uint64_t perft(Board& board, int depth)
     {
         board.makeMove(move);
         uint64_t subNodes = perft<false>(board, depth - 1);
-        board.unmakeMove(move);
+        board.unmakeMove();
         if constexpr (root)
             std::cout << moveToStr(move) << ": " << subNodes << std::endl;
         nodes += subNodes;
@@ -141,7 +141,7 @@ void genOpeningsImpl(Board& board, int depth)
     {
         board.makeMove(move);
         genOpeningsImpl(board, depth - 1);
-        board.unmakeMove(move);
+        board.unmakeMove();
     }
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -52,8 +52,6 @@ SearchResult Search::runSearch(const SearchLimits& limits, bool report)
 
 int Search::search(int alpha, int beta, int depth, int ply)
 {
-    // TODO: add better evaluation function
-    // TODO: move evaluation into it's own file
     if (depth == 0)
         return eval::evaluate(m_Board);
     if (m_Board.isDrawn())
@@ -79,7 +77,7 @@ int Search::search(int alpha, int beta, int depth, int ply)
         m_Nodes++;
         m_Board.makeMove(move);
         int score = -search(-beta, -alpha, depth - 1, ply + 1);
-        m_Board.unmakeMove(move);
+        m_Board.unmakeMove();
 
         if (m_ShouldStop)
             return 0;

--- a/src/search.h
+++ b/src/search.h
@@ -2,6 +2,7 @@
 
 #include "board.h"
 #include "time_man.h"
+#include "tt.h"
 
 struct SearchResult
 {
@@ -18,13 +19,17 @@ public:
     SearchResult runSearch(const SearchLimits& limits, bool report = true);
     uint64_t runBenchSearch(const SearchLimits& limits);
 
-    void newGame();
+    void newGame()
+    {
+        m_TT.reset();
+    }
 private:
     int search(int alpha, int beta, int depth, int ply);
 
     Board m_Board;
     TimeMan m_TimeMan;
     Move m_RootBestMove;
+    TT m_TT;
 
     bool m_ShouldStop;
 

--- a/src/search.h
+++ b/src/search.h
@@ -17,6 +17,8 @@ public:
     void setBoard(const Board& board);
     SearchResult runSearch(const SearchLimits& limits, bool report = true);
     uint64_t runBenchSearch(const SearchLimits& limits);
+
+    void newGame();
 private:
     int search(int alpha, int beta, int depth, int ply);
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -1,0 +1,92 @@
+#include "tt.h"
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <mmintrin.h>
+void prefetchAddr(const void* addr)
+{
+    return _mm_prefetch(static_cast<const char*>(addr), _MM_HINT_T0);
+}
+
+uint64_t mulhi64(uint64_t a, uint64_t b)
+{
+    return __umulh(a, b);
+}
+#elif defined(_GNU_C) || defined(__clang__)
+void prefetchAddr(const void* addr)
+{
+    return __builtin_prefetch(addr);
+}
+
+uint64_t mulhi64(uint64_t a, uint64_t b)
+{
+    unsigned __int128 result = static_cast<unsigned __int128>(a) * static_cast<unsigned __int128>(b);
+    return result >> 64;
+}
+#else
+void prefetchAddr(const void* addr)
+{
+    // fallback
+}
+
+// taken from stockfish https://github.com/official-stockfish/Stockfish/blob/master/src/misc.h#L158
+uint64_t mulhi64(uint64_t a, uint64_t b)
+{
+    uint64_t aL = static_cast<uint32_t>(a), aH = a >> 32;
+    uint64_t bL = static_cast<uint32_t>(b), bH = b >> 32;
+    uint64_t c1 = (aL * bL) >> 32;
+    uint64_t c2 = aH * bL + c1;
+    uint64_t c3 = aL * bH + static_cast<uint32_t>(c2);
+    return aH * bH + (c2 >> 32) + (c3 >> 32);
+}
+#endif
+
+inline int retrieveScore(int score, int ply)
+{
+    if (isWinScore(score))
+    {
+        score -= score < 0 ? -ply : ply;
+    }
+    return score;
+}
+
+inline int storeScore(int score, int ply)
+{
+    if (isWinScore(score))
+    {
+        score += score < 0 ? -ply : ply;
+    }
+    return score;
+}
+
+TT::TT(size_t mb)
+{
+    resize(mb);
+}
+
+size_t TT::index(uint64_t key) const
+{
+    return static_cast<size_t>(mulhi64(key, m_Entries.size()));
+}
+
+void TT::resize(size_t mb)
+{
+    size_t numEntries = mb * 1024 * 1024 / sizeof(TTEntry);
+    m_Entries.resize(numEntries);
+    reset();
+}
+
+bool TT::probe(ZKey key, TTData& data)
+{
+    auto& entry = m_Entries[index(key.value)];
+    if (entry.key != key.value)
+        return false;
+    data.move = entry.move;
+    return true;
+}
+
+void TT::store(ZKey key, Move bestMove)
+{
+    auto& entry = m_Entries[index(key.value)];
+    entry.key = key.value;
+    entry.move = bestMove;
+}

--- a/src/tt.h
+++ b/src/tt.h
@@ -1,0 +1,36 @@
+#include "board.h"
+
+struct TTEntry
+{
+    uint64_t key;
+    Move move;
+};
+
+struct TTData
+{
+    Move move;
+};
+
+class TT
+{
+public:
+    TT(size_t mb);
+    ~TT() = default;
+
+    TT(const TT&) = delete;
+    TT& operator=(const TT&) = delete;
+
+    void resize(size_t mb);
+
+    bool probe(ZKey key, TTData& data);
+    void store(ZKey key, Move bestMove);
+
+    void reset()
+    {
+        std::fill(m_Entries.begin(), m_Entries.end(), TTEntry{});
+    }
+private:
+    size_t index(uint64_t key) const;
+
+    std::vector<TTEntry> m_Entries;
+};

--- a/src/types.h
+++ b/src/types.h
@@ -6,12 +6,12 @@
 struct Square
 {
 public:
-    Square()
-        : m_SubBoard(0), m_SubSquare(0)
+    constexpr Square()
+        : m_SubBoard(static_cast<uint8_t>(-1)), m_SubSquare(static_cast<uint8_t>(-1))
     {
 
     }
-    explicit Square(uint8_t square)
+    constexpr explicit Square(uint8_t square)
     {
         int x = square % 9;
         int y = square / 9;
@@ -23,28 +23,28 @@ public:
         m_SubSquare = subSquareY * 3 + subSquareX;
     }
 
-    Square(uint8_t subBoard, uint8_t subSquare)
+    constexpr Square(uint8_t subBoard, uint8_t subSquare)
         : m_SubBoard(subBoard), m_SubSquare(subSquare)
     {
 
     }
 
-    uint8_t subBoard() const
+    constexpr uint8_t subBoard() const
     {
         return m_SubBoard;
     }
 
-    uint8_t subSquare() const
+    constexpr uint8_t subSquare() const
     {
         return m_SubSquare;
     }
 
-    uint8_t x() const
+    constexpr uint8_t x() const
     {
         return 3 * (m_SubBoard % 3) + m_SubSquare % 3;
     }
 
-    uint8_t y() const
+    constexpr uint8_t y() const
     {
         return 3 * (m_SubBoard / 3) + m_SubSquare / 3;
     }
@@ -71,6 +71,8 @@ struct Move
     constexpr bool operator!=(const Move& other) const noexcept = default;
 };
 
+constexpr Move NULL_MOVE = Move{Square(-1, -1)};
+
 enum class Piece
 {
     NONE,
@@ -90,3 +92,8 @@ constexpr Color operator~(const Color& color)
 }
 
 constexpr int SCORE_WIN = 32700;
+
+constexpr int isWinScore(int score)
+{
+    return score > SCORE_WIN - 256 || score < -SCORE_WIN + 256;
+}

--- a/src/util/prng.h
+++ b/src/util/prng.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+
+// based off of https://stackoverflow.com/a/27160892/20789760
+
+struct PRNG
+{
+public:
+    constexpr PRNG() = default;
+    constexpr void seed(uint64_t s);
+    constexpr uint64_t next64();
+private:
+    uint64_t a, b, c, counter;
+};
+
+constexpr void PRNG::seed(uint64_t s)
+{
+    a = b = c = s;
+    counter = 1;
+    for (int i = 0; i < 12; i++)
+        next64();
+}
+
+constexpr uint64_t PRNG::next64()
+{
+    uint64_t tmp = a + b + counter++;
+    a = b ^ (b >> 12);
+    b = c + (c << 13);
+    c = ((c << 25) | (c >> (64 - 25))) + tmp;
+    return tmp;
+}

--- a/src/zobrist.h
+++ b/src/zobrist.h
@@ -12,6 +12,7 @@ struct Keys
 {
     uint64_t oToMove;
     std::array<std::array<uint64_t, 81>, 2> pieceSquares;
+    std::array<uint64_t, 10> currSubBoard;
 };
 
 constexpr Keys generateZobristKeys()
@@ -24,6 +25,9 @@ constexpr Keys generateZobristKeys()
     for (int color = 0; color < 2; color++)
         for (int square = 0; square < 81; square++)
                 keys.pieceSquares[color][square] = prng.next64();
+
+    for (int i = 0; i < 10; i++)
+        keys.currSubBoard[i] = prng.next64();
 
     keys.oToMove = prng.next64();
     return keys;
@@ -39,6 +43,7 @@ struct ZKey
 
     void flipSideToMove();
     void addPiece(Color color, Square square);
+    void updateCurrSubBoard(int subBoard);
 
     bool operator==(const ZKey& other) const = default;
     bool operator!=(const ZKey& other) const = default;
@@ -52,4 +57,12 @@ inline void ZKey::flipSideToMove()
 inline void ZKey::addPiece(Color color, Square square)
 {
     value ^= zobrist::keys.pieceSquares[static_cast<int>(color)][9 * square.y() + square.x()];
+}
+
+inline void ZKey::updateCurrSubBoard(int subBoard)
+{
+    if (subBoard == -1)
+        value ^= zobrist::keys.currSubBoard[9];
+    else
+        value ^= zobrist::keys.currSubBoard[subBoard];
 }

--- a/src/zobrist.h
+++ b/src/zobrist.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstdint>
+#include <array>
+#include "types.h"
+#include "util/prng.h"
+
+namespace zobrist
+{
+
+struct Keys
+{
+    uint64_t oToMove;
+    std::array<std::array<uint64_t, 81>, 2> pieceSquares;
+};
+
+constexpr Keys generateZobristKeys()
+{
+    Keys keys = {};
+
+    PRNG prng;
+    prng.seed(8367428251681ull);
+
+    for (int color = 0; color < 2; color++)
+        for (int square = 0; square < 81; square++)
+                keys.pieceSquares[color][square] = prng.next64();
+
+    keys.oToMove = prng.next64();
+    return keys;
+}
+
+constexpr Keys keys = generateZobristKeys();
+
+}
+
+struct ZKey
+{
+    uint64_t value = 0;
+
+    void flipSideToMove();
+    void addPiece(Color color, Square square);
+
+    bool operator==(const ZKey& other) const = default;
+    bool operator!=(const ZKey& other) const = default;
+};
+
+inline void ZKey::flipSideToMove()
+{
+    value ^= zobrist::keys.oToMove;
+}
+
+inline void ZKey::addPiece(Color color, Square square)
+{
+    value ^= zobrist::keys.pieceSquares[static_cast<int>(color)][9 * square.y() + square.x()];
+}


### PR DESCRIPTION
```
Score of uttt-tt-move-ordering vs uttt-alpha-beta: 106 - 30 - 70 [0.684] 206
134.52 +/- 39.95
SPRT: llr 2.97, lbound -2.94, ubound 2.94
```

tc: 8+0.08
book: openings_5ply.txt
sprt bounds: [0, 10]

Bench: 10037220