### PR TITLE
History

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SRCS
     "src/types.h"
     "src/zobrist.h"
 
+    "src/util/multi_array.h"
     "src/util/prng.h"
     "src/util/static_vector.h"
 )

--- a/src/move_picker.cpp
+++ b/src/move_picker.cpp
@@ -1,7 +1,7 @@
 #include "move_picker.h"
 
-MovePicker::MovePicker(const Board& board, Move ttMove)
-    : m_Board(board), m_TTMove(ttMove), m_CurrIdx(0)
+MovePicker::MovePicker(const Board& board, Move ttMove, const MultiArray<int32_t, 2, 81>& history)
+    : m_Board(board), m_TTMove(ttMove), m_CurrIdx(0), m_History(history)
 {
     genMoves(m_Board, m_Moves);
     for (int i = 0; i < m_Moves.size(); i++)
@@ -27,5 +27,5 @@ int32_t MovePicker::scoreMove(Move move) const
 {
     if (move == m_TTMove)
         return 100000000;
-    return 0;
+    return m_History[static_cast<int>(m_Board.sideToMove())][9 * move.to.y() + move.to.x()];
 }

--- a/src/move_picker.h
+++ b/src/move_picker.h
@@ -5,7 +5,7 @@
 class MovePicker
 {
 public:
-    MovePicker(const Board& board, Move ttMove);
+    MovePicker(const Board& board, Move ttMove, const MultiArray<int32_t, 2, 81>& history);
 
     Move pickNext();
 private:
@@ -13,6 +13,7 @@ private:
 
     const Board& m_Board;
     Move m_TTMove;
+    const MultiArray<int32_t, 2, 81>& m_History;
     MoveList m_Moves;
     int32_t m_MoveScores[81];
     uint32_t m_CurrIdx;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -26,6 +26,7 @@ SearchResult Search::runSearch(const SearchLimits& limits, bool report)
     m_Nodes = 0;
     m_TimeMan.setLimits(limits);
     m_TimeMan.startSearch();
+    m_History.fill({});
 
     int score = 0;
     Move bestMove = Move{};
@@ -72,7 +73,7 @@ int Search::search(int alpha, int beta, int depth, int ply)
     TTData ttData = {};
     bool ttHit = m_TT.probe(m_Board.key(), ttData);
 
-    MovePicker movePicker(m_Board, ttData.move);
+    MovePicker movePicker(m_Board, ttData.move, m_History);
 
     int bestScore = -SCORE_WIN;
     Move bestMove = NULL_MOVE;
@@ -100,7 +101,10 @@ int Search::search(int alpha, int beta, int depth, int ply)
             }
 
             if (score >= beta)
+            {
+                m_History[static_cast<int>(m_Board.sideToMove())][9 * move.to.y() + move.to.x()] += depth * depth;
                 break;
+            }
         }
     }
 

--- a/src/search.h
+++ b/src/search.h
@@ -31,6 +31,8 @@ private:
     Move m_RootBestMove;
     TT m_TT;
 
+    MultiArray<int32_t, 2, 81> m_History;
+
     bool m_ShouldStop;
 
     uint64_t m_Nodes;

--- a/src/util/multi_array.h
+++ b/src/util/multi_array.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+// stormphrax yoink
+namespace internal
+{
+    template<typename T, size_t N, size_t ...Ns>
+    struct MultiArrayImpl
+    {
+        using Type = std::array<typename MultiArrayImpl<T, Ns...>::Type, N>;
+    };
+
+    template<typename T, size_t N>
+    struct MultiArrayImpl<T, N>
+    {
+        using Type = std::array<T, N>;
+    };
+}
+
+template<typename T, size_t ...Ns>
+using MultiArray = typename internal::MultiArrayImpl<T, Ns...>::Type;

--- a/src/zobrist.h
+++ b/src/zobrist.h
@@ -4,6 +4,7 @@
 #include <array>
 #include "types.h"
 #include "util/prng.h"
+#include "util/multi_array.h"
 
 namespace zobrist
 {
@@ -11,7 +12,7 @@ namespace zobrist
 struct Keys
 {
     uint64_t oToMove;
-    std::array<std::array<uint64_t, 81>, 2> pieceSquares;
+    MultiArray<uint64_t, 2, 81> pieceSquares;
     std::array<uint64_t, 10> currSubBoard;
 };
 


### PR DESCRIPTION
```
Score of uttt-history vs uttt-tt-move-ordering: 125 - 52 - 148 [0.612] 325
79.39 +/- 27.99
SPRT: llr 2.97, lbound -2.94, ubound 2.94
```
tc: 8+0.08
book: openings_5ply.txt
sprt bounds: [0, 10]

Bench: 9159792