### PR TITLE
tt cutoffs

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -75,18 +75,24 @@ void TT::resize(size_t mb)
     reset();
 }
 
-bool TT::probe(ZKey key, TTData& data)
+bool TT::probe(ZKey key, int ply, TTData& data)
 {
     auto& entry = m_Entries[index(key.value)];
     if (entry.key != key.value)
         return false;
     data.move = entry.move;
+    data.score = retrieveScore(entry.score, ply);
+    data.depth = entry.depth;
+    data.bound = entry.bound;
     return true;
 }
 
-void TT::store(ZKey key, Move bestMove)
+void TT::store(ZKey key, int ply, Move bestMove, int score, int depth, TTBound bound)
 {
     auto& entry = m_Entries[index(key.value)];
     entry.key = key.value;
     entry.move = bestMove;
+    entry.score = storeScore(score, ply);
+    entry.depth = depth;
+    entry.bound = bound;
 }

--- a/src/tt.h
+++ b/src/tt.h
@@ -2,15 +2,29 @@
 
 #include "board.h"
 
+enum class TTBound : uint8_t
+{
+    NONE,
+    UPPER,
+    LOWER,
+    EXACT
+};
+
 struct TTEntry
 {
     uint64_t key;
+    int16_t score;
     Move move;
+    uint8_t depth;
+    TTBound bound;
 };
 
 struct TTData
 {
     Move move;
+    int score;
+    int depth;
+    TTBound bound;
 };
 
 class TT
@@ -24,8 +38,8 @@ public:
 
     void resize(size_t mb);
 
-    bool probe(ZKey key, TTData& data);
-    void store(ZKey key, Move bestMove);
+    bool probe(ZKey key, int ply, TTData& data);
+    void store(ZKey key, int ply, Move bestMove, int score, int depth, TTBound bound);
 
     void reset()
     {


### PR DESCRIPTION
```
Score of uttt-tt-cutoffs vs uttt-history-malus: 152 - 78 - 204 [0.585] 434
59.82 +/- 23.83
SPRT: llr 2.97, lbound -2.94, ubound 2.94
```
tc: 8+0.08
book: openings_5ply.txt
sprt bounds: [0, 10]

Bench: 6625654