### PR TITLE
Reverse Futility Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -55,8 +55,9 @@ SearchResult Search::runSearch(const SearchLimits& limits, bool report)
 
 int Search::search(int alpha, int beta, int depth, int ply)
 {
+    int staticEval = eval::evaluate(m_Board);
     if (depth == 0)
-        return eval::evaluate(m_Board);
+        return staticEval;
     if (m_Board.isDrawn())
         return 0;
     if (m_Board.isLost())
@@ -69,6 +70,9 @@ int Search::search(int alpha, int beta, int depth, int ply)
     }
 
     bool root = ply == 0;
+
+    if (!root && depth <= 4 && staticEval - 15 * depth >= beta)
+        return staticEval;
 
     TTData ttData = {};
     bool ttHit = m_TT.probe(m_Board.key(), ply, ttData);


### PR DESCRIPTION
```
Score of uttt-rfp2 vs uttt-tt-cutoffs: 89 - 20 - 88 [0.675] 197
127.07 +/- 36.42
SPRT: llr 2.96, lbound -2.94, ubound 2.94
```
tc: 8+0.08
book: openings_5ply.txt
sprt bounds: [0, 10]

Bench: 546364