### PR TITLE
Fix draw/win detection

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -278,15 +278,15 @@ int main()
             }
             else if (tok == "result")
             {
-                if (currBoard.isDrawn())
-                    std::cout << "response draw" << std::endl;
-                else if (currBoard.isLost())
+                if (currBoard.isLost())
                 {
                     if (currBoard.sideToMove() == player1)
                         std::cout << "response p2win" << std::endl;
                     else
                         std::cout << "response p1win" << std::endl;
                 }
+                else if (currBoard.isDrawn())
+                    std::cout << "response draw" << std::endl;
                 else
                     std::cout << "response none" << std::endl;
             }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -91,10 +91,10 @@ int Search::search(int alpha, int beta, int depth, int ply)
     int staticEval = eval::evaluate(m_Board);
     if (depth == 0)
         return staticEval;
-    if (m_Board.isDrawn())
-        return 0;
     if (m_Board.isLost())
         return -SCORE_WIN + ply;
+    if (m_Board.isDrawn())
+        return 0;
 
     if (m_Nodes % 512 == 0 && m_TimeMan.shouldStopHard())
     {


### PR DESCRIPTION
```
Score of uttt-fix vs uttt-soft-tm-fixed-gameover: 172 - 100 - 126 [0.590] 398
63.55 +/- 28.49
SPRT: llr 2.95, lbound -2.94, ubound 2.94
```
tc: 8+0.08
book: openings_5ply.txt
sprt bounds: [0, 10]

Draw detection returns false positives if the board is won, so wins need to be checked for first
Bench: 14127323