### PR TITLE
LMR + PVS

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -25,7 +25,7 @@ public:
     }
 private:
     int aspWindows(int depth, int prevScore);
-    int search(int alpha, int beta, int depth, int ply);
+    int search(int alpha, int beta, int depth, int ply, bool pvNode);
 
     Board m_Board;
     TimeMan m_TimeMan;


### PR DESCRIPTION
```
Score of uttt-pvs-lmr vs uttt-fix: 186 - 108 - 200 [0.579] 494
55.32 +/- 23.73
SPRT: llr 2.94, lbound -2.94, ubound 2.94
```
tc: 8+0.08
book: openings_5ply.txt
sprt bounds: [0, 10]

Just pvs was giga neutral so adding lmr with it

Bench: 6562514