### PR TITLE
Log lmr formula

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -3,6 +3,22 @@
 #include "evaluate.h"
 #include "move_picker.h"
 
+
+MultiArray<int, 256, 256> computeLMRTable()
+{
+    MultiArray<int, 256, 256> table = {};
+    for (int d = 1; d < 256; d++)
+    {
+        for (int m = 1; m < 256; m++)
+        {
+            table[d][m] = 0.74 + std::log(d) * std::log(m) / 2.8;
+        }
+    }
+    return table;
+}
+
+auto lmrTable = computeLMRTable();
+
 Search::Search()
     : m_TT(64)
 {
@@ -138,8 +154,8 @@ int Search::search(int alpha, int beta, int depth, int ply, bool pvNode)
         else
         {
             int reduction = 0;
-            if (movesPlayed >= 6 - (depth >= 5) - (depth >= 7) && depth >= 3)
-                reduction = 1;
+            if (movesPlayed >= 4 && depth >= 3)
+                reduction = lmrTable[depth][movesPlayed];
 
             score = -search(-alpha - 1, -alpha, depth - 1 - reduction, ply + 1, false);
             if (score > alpha && reduction > 0)


### PR DESCRIPTION
```
Score of uttt-log-lmr vs uttt-pvs-lmr: 117 - 42 - 102 [0.644] 261
102.73 +/- 33.42
SPRT: llr 2.97, lbound -2.94, ubound 2.94
```
tc: 8+0.08
book: openings_5ply.txt
sprt bounds: [0, 10]

Bench: 2228455